### PR TITLE
1차 리팩토링

### DIFF
--- a/MyWeatherApp/MyWeatherApp/View/LocationView.swift
+++ b/MyWeatherApp/MyWeatherApp/View/LocationView.swift
@@ -27,9 +27,6 @@ struct LocationView: View {
                         .pickerStyle(.menu)
                     }
                     .listRowBackground(Color.clear)
-                    .onChange(of: viewModel.tempSido) { oldValue, newValue in
-                        viewModel.selectFirstCity(sido: newValue)
-                    }
                     
                     HStack {
                         Text("시 / 군 / 구")

--- a/MyWeatherApp/MyWeatherApp/View/WeatherView.swift
+++ b/MyWeatherApp/MyWeatherApp/View/WeatherView.swift
@@ -53,29 +53,7 @@ struct WeatherView: View {
                         .padding(.horizontal, 60)
                         .padding(.bottom, 36)
                     } else {
-                        Image(systemName: "network.slash")
-                            .resizable()
-                            .renderingMode(.template)
-                            .scaledToFit()
-                            .padding(.horizontal, 76)
-                        
-                        Text("-")
-                            .font(.temperature)
-                        
-                        Text("네트워크 오류")
-                        
-                        Spacer()
-                            .frame(maxHeight: 40)
-                        
-                        HStack {
-                            AdditionalInformationView(type: .wind, value: "-")
-                            
-                            Spacer()
-                            
-                            AdditionalInformationView(type: .humidity, value: "-")
-                        }
-                        .padding(.horizontal, 60)
-                        .padding(.bottom, 36)
+                        NetworkErrorView()
                     }
                 }
             }
@@ -98,6 +76,34 @@ struct WeatherView: View {
                     .presentationCornerRadius(36)
             }
         }
+    }
+}
+
+private struct NetworkErrorView: View {
+    fileprivate var body: some View {
+        Image(systemName: "network.slash")
+            .resizable()
+            .renderingMode(.template)
+            .scaledToFit()
+            .padding(.horizontal, 76)
+        
+        Text("-")
+            .font(.temperature)
+        
+        Text("네트워크 오류")
+        
+        Spacer()
+            .frame(maxHeight: 40)
+        
+        HStack {
+            AdditionalInformationView(type: .wind, value: "-")
+            
+            Spacer()
+            
+            AdditionalInformationView(type: .humidity, value: "-")
+        }
+        .padding(.horizontal, 60)
+        .padding(.bottom, 36)
     }
 }
 

--- a/MyWeatherApp/MyWeatherApp/View/WeatherViewModel.swift
+++ b/MyWeatherApp/MyWeatherApp/View/WeatherViewModel.swift
@@ -99,11 +99,7 @@ class WeatherViewModel: ObservableObject {
             
             if let dataArr = encodedData?.components(separatedBy: "\n").map({ $0.trimmingCharacters(in: .newlines).components(separatedBy: ",") }) {
                 for arr in dataArr {
-                    if self.cityList[arr[0]] == nil {    // 키 값이 존재하지 않으면
-                        self.cityList[arr[0]] = [City(sigungu: arr[1], lon: arr[2], lat: arr[3])]
-                    } else {    // 이미 키 값이 존재하면
-                        self.cityList[arr[0]]?.append(City(sigungu: arr[1], lon: arr[2], lat: arr[3]))
-                    }
+                    self.cityList[arr[0], default: []].append(City(sigungu: arr[1], lon: arr[2], lat: arr[3]))
                 }
             }
         } catch {

--- a/MyWeatherApp/MyWeatherApp/View/WeatherViewModel.swift
+++ b/MyWeatherApp/MyWeatherApp/View/WeatherViewModel.swift
@@ -33,7 +33,11 @@ class WeatherViewModel: ObservableObject {
     @Published var weatherInformation: WeatherInformation?
     
     @Published var showLocationSheet: Bool = false
-    @Published var tempSido: String = ""
+    @Published var tempSido: String = "" {
+        didSet {
+            selectFirstCity(sido: tempSido)
+        }
+    }
     @Published var tempCity = City(sigungu: "", lon: "", lat: "")
     
     private var cancellables = Set<AnyCancellable>()
@@ -82,7 +86,7 @@ class WeatherViewModel: ObservableObject {
         closeLocationSheet()
     }
     
-    func selectFirstCity(sido: String) {
+    private func selectFirstCity(sido: String) {
         self.tempCity = cityList[sido]![0]
     }
     


### PR DESCRIPTION
- 뷰에서 onChange로 실행되던 함수를 뷰모델의 변수 내 didSet에서 실행되도록 변경 및 해당 함수 private으로 변경
- 지역 데이터 로드 시 딕셔너리의 키로 접근 후 nil 값을 판단하던 조건문에서 딕셔너리의 default를 활용하여 조건문 제거
- 네트워크 오류 시 표시되는 뷰를 별도의 구조체로 분리